### PR TITLE
Prevent hooks execution when plugin is not active

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -49,6 +49,10 @@ function plugin_init_databaseinventory()
 
     $PLUGIN_HOOKS['config_page']['databaseinventory'] = 'front/menu.php';
 
+    if (!Plugin::isPluginActive('databaseinventory')) {
+        return false;
+    }
+
     $PLUGIN_HOOKS['handle_inventory_task']['databaseinventory'] = ['PluginDatabaseinventoryTask', 'handleInventoryTask'];
     $PLUGIN_HOOKS['inventory_get_params']['databaseinventory']  = ['PluginDatabaseinventoryTask', 'inventoryGetParams'];
     $PLUGIN_HOOKS['handle_agent_response']['databaseinventory'] = ['PluginDatabaseinventoryInventoryAction', 'HandleAgentResponse'];


### PR DESCRIPTION
GLPI is supposed to prevent this, but I guess it is safer to not declare hooks if plugin is not active.