### PR TITLE
Fix(Search): Fix undefined array key during database inventory task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+### Fixed
+
+- Fix `Undefined array key "glpiname"` during database inventory task.
+
 ## [1.0.3] - 2025-07-10
 
 ### Fixed

--- a/inc/computergroupdynamic.class.php
+++ b/inc/computergroupdynamic.class.php
@@ -178,16 +178,15 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
             'value'      => $computer->fields['id'],
         ];
 
-        $bkp_glpi_name = $_SESSION['glpiname'];
-        $_SESSION['glpiname'] = 'databaseinventory_plugin';
-
+        if (!isset($_SESSION['glpiname'])) {
+            Session::start();
+            $_SESSION['glpiname'] = 'databaseinventory_plugin';
+        }
         $search_params = Search::manageParams('Computer', $search);
         $data          = Search::prepareDatasForSearch('Computer', $search_params);
         Search::constructSQL($data);
         Search::constructData($data);
         $count = $data['data']['totalcount'];
-
-        $_SESSION['glpiname'] = $bkp_glpi_name;
 
         return $count;
     }

--- a/inc/computergroupdynamic.class.php
+++ b/inc/computergroupdynamic.class.php
@@ -160,7 +160,6 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
     {
         $search_params = Search::manageParams('Computer', unserialize($this->fields['search']));
         $data          = Search::prepareDatasForSearch('Computer', $search_params);
-
         Search::constructSQL($data);
         Search::constructData($data);
         $count = $data['data']['totalcount'];

--- a/inc/computergroupdynamic.class.php
+++ b/inc/computergroupdynamic.class.php
@@ -161,14 +161,9 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
         $search_params = Search::manageParams('Computer', unserialize($this->fields['search']));
         $data          = Search::prepareDatasForSearch('Computer', $search_params);
 
-        $bkp_glpi_name = $_SESSION['glpiname'];
-        $_SESSION['glpiname'] = 'databaseinventory_plugin';
-
         Search::constructSQL($data);
         Search::constructData($data);
         $count = $data['data']['totalcount'];
-
-        $_SESSION['glpiname'] = $bkp_glpi_name;
 
         return $count;
     }
@@ -184,11 +179,16 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
             'value'      => $computer->fields['id'],
         ];
 
+        $bkp_glpi_name = $_SESSION['glpiname'];
+        $_SESSION['glpiname'] = 'databaseinventory_plugin';
+
         $search_params = Search::manageParams('Computer', $search);
         $data          = Search::prepareDatasForSearch('Computer', $search_params);
         Search::constructSQL($data);
         Search::constructData($data);
         $count = $data['data']['totalcount'];
+
+        $_SESSION['glpiname'] = $bkp_glpi_name;
 
         return $count;
     }

--- a/inc/computergroupdynamic.class.php
+++ b/inc/computergroupdynamic.class.php
@@ -160,9 +160,15 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
     {
         $search_params = Search::manageParams('Computer', unserialize($this->fields['search']));
         $data          = Search::prepareDatasForSearch('Computer', $search_params);
+
+        $bkp_glpi_name = $_SESSION['glpiname'];
+        $_SESSION['glpiname'] = 'databaseinventory_plugin';
+
         Search::constructSQL($data);
         Search::constructData($data);
         $count = $data['data']['totalcount'];
+
+        $_SESSION['glpiname'] = $bkp_glpi_name;
 
         return $count;
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

When the task involves configuring databases to be inventoried, this request is made through an **autonomous curl call**.

Under these conditions, `$_SESSION['glpiname']` is not initialized with the name of the user who is connecting, which causes the following error when performing a search using the `Search.php` class:

```shell
[2025-09-02 13:29:03] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "glpiname" in D:\wamp\www\glpi\src\Search.php at line 729
  Backtrace :
  ...nventory\inc\computergroupdynamic.class.php:183 Search::constructSQL()
  plugins\databaseinventory\inc\task.class.php:244   PluginDatabaseinventoryComputerGroupDynamic->isDynamicSearchMatchComputer()
  src\Plugin.php:1763                                PluginDatabaseinventoryTask::handleInventoryTask()
  src\Inventory\Request.php:420                      Plugin::doHookFunction()
  src\Inventory\Request.php:130                      Glpi\Inventory\Request->handleInventoryTask()
  src\Inventory\Request.php:340                      Glpi\Inventory\Request->handleTask()
  src\Inventory\Request.php:83                       Glpi\Inventory\Request->contact()
  src\Agent\Communication\AbstractRequest.php:359    Glpi\Inventory\Request->handleAction()
  src\Agent\Communication\AbstractRequest.php:271    Glpi\Agent\Communication\AbstractRequest->handleJSONRequest()
  front\inventory.php:100                            Glpi\Agent\Communication\AbstractRequest->handleRequest()
  plugins\glpiinventory\front\communication.php:72   include_once()
  plugins\glpiinventory\index.php:45                 include_once()
```

This PR **forcibly sets `$_SESSION['glpiname']` to `'databaseinventory_plugin'`** (useful for debugging) during the execution of the search, and **restores the original value** after the call to the `Search` class.

Fix : https://github.com/pluginsGLPI/databaseinventory/issues/73

## Screenshots (if appropriate):
