### PR TITLE
Fix(Task): prevent undefined index when computer not already linkedo agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+### Fixed
+
+- Fix `Undefined array key "id"` when computer not already linkedo agent
+
 ## [1.0.4] - 2025-09-04
 
 ### Fixed

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -138,7 +138,7 @@ class PluginDatabaseinventoryTask extends CommonGLPI
         $database_param_found = [];
 
         // only Computer type
-        if (get_class($computer) == Computer::getType()) {
+        if (get_class($computer) == Computer::getType() && !$computer->isNewItem()) {
             $database_param_table               = PluginDatabaseinventoryDatabaseParam::getTable() ;
             $database_param_computergroup_table = PluginDatabaseinventoryDatabaseParam_ComputerGroup::getTable();
             $computer_group_static_table        = PluginDatabaseinventoryComputerGroupStatic::getTable();


### PR DESCRIPTION
…o agent

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #79 

1. The agent runs for the first time (the computer and agent does not yet exists in GLPI).
2. The agent contacts GLPI for the first time (initial "contact" phase).
3. GLPI creates the agent entry (without any associated asset at this stage).
4. GLPI calls the **DatabaseInventory** plugin to check whether any parameters will need to be requested later depending of related Computer (**this is where the warning is triggered**).
5. GLPI returns the tasks to be executed (inventory + database parameter request)(in this case only inventory).
6. The agent performs its local inventory.
7. The agent sends the inventory results to GLPI.
8. GLPI processes the inventory file and creates or updates the computer record.
9. GLPI updates the agent entry to link it with the corresponding computer.



## Screenshots (if appropriate):
