### PR TITLE
Fix: decode group search filter as array instead of object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [UNRELEASED]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Decode dynamic group search filter as an array instead of an object
+
 ## [1.1.3] - 2026-05-05
 
 ### Fixed

--- a/inc/computergroup.class.php
+++ b/inc/computergroup.class.php
@@ -273,6 +273,8 @@ SQL;
         if ($DB->tableExists($table)) {
             $DB->doQuery('DROP TABLE IF EXISTS `' . self::getTable() . '`');
         }
+
+        (new DisplayPreference())->deleteByCriteria(['itemtype' => self::class]);
     }
 
     public static function getIcon()

--- a/inc/computergroupdynamic.class.php
+++ b/inc/computergroupdynamic.class.php
@@ -29,6 +29,7 @@
  */
 
 use function Safe\json_decode;
+use function Safe\unserialize;
 use function Safe\json_encode;
 use function Safe\ob_start;
 use function Safe\ob_get_clean;
@@ -182,7 +183,7 @@ class PluginDatabaseinventoryComputerGroupDynamic extends CommonDBTM
     public function isDynamicSearchMatchComputer(Computer $computer)
     {
         // add new criteria to force computer ID
-        $search = json_decode((string) $this->fields['search']);
+        $search = json_decode((string) $this->fields['search'], true, 512, JSON_THROW_ON_ERROR);
 
         $search['criteria'][] = [
             'link'       => 'AND',

--- a/inc/credential.class.php
+++ b/inc/credential.class.php
@@ -246,6 +246,8 @@ SQL;
         if ($DB->tableExists($table)) {
             $DB->doQuery('DROP TABLE IF EXISTS `' . self::getTable() . '`');
         }
+
+        (new DisplayPreference())->deleteByCriteria(['itemtype' => self::class]);
     }
 
     public static function getIcon()

--- a/inc/databaseparam.class.php
+++ b/inc/databaseparam.class.php
@@ -277,6 +277,8 @@ SQL;
         if ($DB->tableExists($table)) {
             $DB->doQuery('DROP TABLE IF EXISTS `' . self::getTable() . '`');
         }
+
+        (new DisplayPreference())->deleteByCriteria(['itemtype' => self::class]);
     }
 
     public static function getIcon()

--- a/rector.php
+++ b/rector.php
@@ -28,30 +28,27 @@
  * -------------------------------------------------------------------------
  */
 
+use Rector\Configuration\RectorConfigBuilder;
+
 require_once __DIR__ . '/../../src/Plugin.php';
 
-use Rector\Caching\ValueObject\Storage\FileCacheStorage;
-use Rector\Config\RectorConfig;
-use Rector\ValueObject\PhpVersion;
+$baseline_file = __DIR__ . '/../../PluginsRector.php';
+if (!file_exists($baseline_file)) {
+    throw new RuntimeException(
+        sprintf(
+            'Unable to find "%s". Running rector on a plugin requires a GLPI development checkout that ships PluginsRector.php.',
+            $baseline_file,
+        ),
+    );
+}
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/ajax',
-        __DIR__ . '/front',
-        __DIR__ . '/inc',
-    ])
-    ->withPhpVersion(PhpVersion::PHP_82)
-    ->withCache(
-        cacheDirectory: __DIR__ . '/var/rector',
-        cacheClass: FileCacheStorage::class,
-    )
-    ->withRootFiles()
-    ->withParallel(timeoutSeconds: 300)
-    ->withImportNames(removeUnusedImports: true)
-    ->withPreparedSets(
-        deadCode: true,
-        codeQuality: true,
-        codingStyle: true,
-    )
-    ->withPhpSets(php82: true) // apply PHP sets up to PHP 8.2
-;
+$baseline = require $baseline_file;
+
+/** @var RectorConfigBuilder $config */
+$config = $baseline([
+    __DIR__ . '/ajax',
+    __DIR__ . '/front',
+    __DIR__ . '/inc',
+]);
+
+return $config;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I performed self-review code.
- [ ] I added tests (when available) prove fix is effective or feature works.
- [x] I updated CHANGELOG short functional description fix or new feature.
- [ ] This change requires documentation update.

## Description

- fixes !45316
`json_decode` was called without the associative flag, so the search filter was returned as a `stdClass` object instead of an array.
This broke the criteria array access used to force the computer ID filter.


## Screenshots (if appropriate):
